### PR TITLE
added responsive nav bar and iframe for section id replacement

### DIFF
--- a/public/assets/css/layout.css
+++ b/public/assets/css/layout.css
@@ -7,6 +7,7 @@
   width: 1400px;
 }
 
+
   @media screen and (min-width: 961px) and (max-width: 1880px) {
 
     .container {
@@ -1514,3 +1515,31 @@
           }
 
   }
+
+/* by default, my responsive menu won't show up but then it will when the breakpoint of tablet is hit. */
+#responsive-header {
+  display:none;
+}
+/* This is media query for tablet mode-when the user hits the breakpoint, 
+the hamburger menu will display a fixed nav menu instead */
+@media only screen and (min-width : 768px) and (max-width: 960px){
+ #responsive-header {
+  display: block;
+  background-color: rgb(241, 187, 196);
+  color: black;
+  font-family: 'Yanone Kaffeesatz', sans-serif;
+ }
+ #responsive-header #title {
+   font-size: 40px;
+ }
+ #responsive-header #logo p {
+   font-size: 40px;
+ }
+ .avatar48 {
+   display:none !important;
+
+ }
+ .toggle {
+   display:none;
+ }
+}

--- a/public/assets/css/modules.css
+++ b/public/assets/css/modules.css
@@ -507,7 +507,7 @@ button,
 }
 
 @media screen and (max-width: 960px) {
-
+/* had to change the breakpoint for the sidebar to 960 so that this sidebar will NOT Show up in tablet mode */
   /* Basic */
 
     html, body {

--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,24 @@
 	<body class="is-preload">
 
 		<!-- Header -->
+		<div id="responsive-header">
+			<div id="logo">
+				<span class="image avatar48"><img src="images/avatar.jpg" alt="" /></span>
+				<h1 id="title">Riva</h1>
+				<p>Software Engineer</p>
+			</div>
+
+			<nav id="nav">
+				<div>
+					<span><a href="#top" id="top-link"><span class="icon fa-home">Intro</span></a></span>
+					<span><a href="#portfolio" id="portfolio-link"><span class="icon fa-th">Portfolio</span></a></span>
+					<span><a href="#about" id="about-link"><span class="icon fa-user">About Me</span></a></span>
+					<span><a href="#contact" id="contact-link"><span class="icon fa-envelope">Contact</span></a></span>
+				</div>
+			</nav>
+
+	</div>
+
 			<div id="header">
 
 				<div class="top">
@@ -57,6 +75,22 @@
 			<div id="main">
 
 				<!-- Intro -->
+				<section id="video-section">
+					<div class="container">
+						<iframe width="560" height="315" src="https://www.youtube.com/embed/-XJMGhf6mNA" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>" 
+						<header>
+							<h2 class="alt">Hi! I'm <strong>Riva!</strong><br />
+								<p>Student at Code Fellows</p>
+						 <a href=""></a></h2>
+							<p></p>
+						</header>
+
+						<footer>
+							<a href="#portfolio" class="button scrolly">Check out My Work</a>
+						</footer>
+
+					</div>
+				</section>
 					<section id="top" class="one dark cover">
 						<div class="container">
 


### PR DESCRIPTION
- Added media query In for  tablet view that shows a fixed navigation menu instead of a hamburger menu once the breakpoint it hit
- Converted the large image at the top of my portfolio to a video background by duplicating the ```<section></section> code and adding in an iframe (youtube video)
- Once the breakpoint for tablet view is hit, I changed the background color and font-size of the```#title``` and ```<p></p>``` tag in navigation menu.